### PR TITLE
Remove 10ms delay in disableProgramming()

### DIFF
--- a/src/NETSGPClient.cpp
+++ b/src/NETSGPClient.cpp
@@ -247,7 +247,6 @@ void NETSGPClient::enableProgramming()
 void NETSGPClient::disableProgramming()
 {
     digitalWrite(mProgPin, HIGH);
-    delay(10);
 }
 
 bool NETSGPClient::fillInverterStatusFromBuffer(const uint8_t* buffer, InverterStatus& status)


### PR DESCRIPTION
disableProgramming() is called when initializing NETSGPClient and having the delay on initialization breaks the code on ESP32-C3 and creates a bootloop:

Guru Meditation Error: Core  0 panic'ed (Store access fault). Exception was unhandled.

Rebooting...
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x3 (RTC_SW_SYS_RST),boot:0x8 (SPI_FAST_FLASH_BOOT) Saved PC:0x40381990
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd5810,len:0x438
load:0x403cc710,len:0x91c
load:0x403ce710,len:0x25b0
entry 0x403cc710
Guru Meditation Error: Core  0 panic'ed (Store access fault). Exception was unhandled.

Core  0 register dump:
MEPC    : 0x40388d66  RA      : 0x4038998e  SP      : 0x3fcde290  GP      : 0x3fc8f200  
(...)
Some info I could get from the register dump leads to freertos tasks not beeing happy with the delay() for whatever reason:

riscv32-esp-elf-addr2line -pfiaC -e firmware.elf 0x40388d66 0x40388d66: prvAddCurrentTaskToDelayedList at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/freertos/tasks.c:5977

riscv32-esp-elf-addr2line -pfiaC -e firmware.elf 0x4038998e 0x4038998e: vTaskDelay at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/freertos/tasks.c:1584